### PR TITLE
fix some bugs

### DIFF
--- a/src/hero.ts
+++ b/src/hero.ts
@@ -61,6 +61,7 @@ export const loadHero = () => {
     hero.y = HEIGHT / 2
     stats.health = 100
     state = State.idle
+    pendingDamage = 0
     flipped = false
     invulnerable = false
 

--- a/src/stat.ts
+++ b/src/stat.ts
@@ -314,7 +314,7 @@ export const resetStats = () => {
 
 export const increaseXp = () => {
     stats.xp += COIN_XP
-    if (stats.xp > stats.levelXp) {
+    if (stats.xp >= stats.levelXp) {
         stats.xp -= stats.levelXp
         stats.levelXp += LEVEL_XP_CAP_INC
         powerupMenu()


### PR DESCRIPTION
- fix increaseXp() to reset to zero right when the limit is reached and not on overflow only
- reset `pendingDamage=0` in loadHero() to avoid re-starting new game without full HP sometimes